### PR TITLE
ES-2584 | Support Dynamic JWK Type Handling in getJWKString Utility

### DIFF
--- a/esignet-core/src/main/java/io/mosip/esignet/core/util/IdentityProviderUtil.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/util/IdentityProviderUtil.java
@@ -226,12 +226,11 @@ public class IdentityProviderUtil {
                     default:
                         log.error("Unsupported key type '{}' in JWK", keyType);
                 }
-            } else {
-                log.error("Missing 'kty' field in JWK: {}", jwk);
             }
         } catch (JoseException e) {
             log.error("Error creating JWK: {}", e.getMessage(), e);
         }
+        log.error("Missing 'kty' field in JWK: {}", jwk);
         throw new EsignetException(ErrorConstants.INVALID_PUBLIC_KEY);
     }
 

--- a/esignet-core/src/test/java/io/mosip/esignet/core/IdentityProviderUtilTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/IdentityProviderUtilTest.java
@@ -150,7 +150,7 @@ public class IdentityProviderUtilTest {
     }
     
     @Test
-    public void test_getJWKString_withValidAndMissingKty_thenFail() {
+    public void getJWKString_withValidAndMissingKty_thenFail() {
         Assert.assertNotNull(IdentityProviderUtil.getJWKString((Map<String, Object>) generateJWK_RSA().getRequiredParams()));
         try {
             IdentityProviderUtil.getJWKString(new HashMap<String, Object>()); // missing kty
@@ -161,7 +161,7 @@ public class IdentityProviderUtilTest {
     }
 
     @Test
-    public void test_getJWKString_withUnsupportedKty_thenFail() {
+    public void getJWKString_withUnsupportedKty_thenFail() {
         Map<String, Object> jwkMap = new HashMap<>();
         jwkMap.put("kty", "OCT"); // Unsupported key type
 
@@ -174,7 +174,7 @@ public class IdentityProviderUtilTest {
     }
 
     @Test
-    public void test_getJWKString_withValidRSAKey_thenPass() throws Exception {
+    public void getJWKString_withValidRSAKey_thenPass() throws Exception {
         Map<String, Object> jwkMap = new HashMap<>();
         jwkMap.put("kty", "RSA");
         jwkMap.put("n", "oahUIzUup5kqncCkHk5Zb1pRrLx7e6YtM-9jX1f5e6mHnZFkC2LJUZ0sEh0n5Y5KnQfW9s7d7gK2b8P0EEl0h3ZyHkWzA3YbsgzB4pDxP4RxMZ1I8xD2z3UvfA1zjvKDHz6wEweq4hVJ8nS8GzZJ2E_vb3s");
@@ -185,7 +185,7 @@ public class IdentityProviderUtilTest {
     }
 
     @Test
-    public void test_getJWKString_withValidECKey_thenPass() throws Exception {
+    public void getJWKString_withValidECKey_thenPass() throws Exception {
         Map<String, Object> jwkMap = new HashMap<>();
         jwkMap.put("kty", "EC");
         jwkMap.put("crv", "P-256");


### PR DESCRIPTION
IdentityProviderUtil.getJWKString updates -:
   -- Dynamically handles both RSA and EC key types instead of assuming RSA only.
   --Throws a proper EsignetException for unsupported or missing key types.
   -- Improves logging for missing or invalid kty values.

IdentityProviderUtilTest - Unit tests added/updated -:
   -- Tests for RSA and EC keys.
   -- Tests for missing kty and unsupported key types.
   -- Added helper method generateTestJWK to create test keys dynamically.