### PR TITLE
MOSIP-43368-Automated Negative test cases for PAR

### DIFF
--- a/api-test/src/main/resources/esignet/PAR/OauthPar/OauthPar.yml
+++ b/api-test/src/main/resources/esignet/PAR/OauthPar/OauthPar.yml
@@ -26,3 +26,138 @@ OauthPar:
 }'
       output: '{
 }'
+   ESignet_OauthPar_Empty_State:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthPar_02
+      description: Validate successful PAR request with missing state
+      role: resident
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: esignet/PAR/OauthPar/OauthPar
+      outputTemplate: esignet/PAR/OauthPar/OauthParResult
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "$REMOVE$",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+}'
+   ESignet_OauthPar_Missing_nonce:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthPar_03
+      description: Validate successful PAR request with missing nonce state
+      role: resident
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: esignet/PAR/OauthPar/OauthPar
+      outputTemplate: esignet/PAR/OauthPar/OauthParResult
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$REMOVE$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+}'
+   ESignet_OauthPar_Valid_ASCII_value:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthPar_04
+      description: Validate successful PAR request with valid ASCII value
+      role: resident
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: esignet/PAR/OauthPar/OauthPar
+      outputTemplate: esignet/PAR/OauthPar/OauthParResult
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "page",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+}'
+   ESignet_OauthPar_unkown_acr_values:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthPar_05
+      description: Validate successful PAR request with valid ASCII value
+      role: resident
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: esignet/PAR/OauthPar/OauthPar
+      outputTemplate: esignet/PAR/OauthPar/OauthParResult
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "page",
+       "prompt": "login",
+       "acr_values": "urn:mace:incommon:iap:password",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+}'
+   ESignet_OauthPar_valid_JWT_values:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthPar_06
+      description: Validate successful PAR request with valid JWT value
+      role: resident
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: esignet/PAR/OauthPar/OauthPar
+      outputTemplate: esignet/PAR/OauthPar/OauthParResult
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "page",
+       "prompt": "login",
+       "acr_values": "urn:mace:incommon:iap:password",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+}'

--- a/api-test/src/main/resources/esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios.hbs
+++ b/api-test/src/main/resources/esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios.hbs
@@ -1,0 +1,16 @@
+{
+  "requestTime": "{{requestTime}}",
+    "client_id": "{{client_id}}",
+    "scope": "{{scope}}",
+    "response_type": "{{response_type}}",
+    "redirect_uri": "{{redirect_uri}}",
+    "display": "{{display}}",
+    "prompt": "{{prompt}}",
+    "acr_values": "{{acr_values}}",
+    "nonce": "{{nonce}}",
+    "state": "{{state}}",
+    "claim_locales": "{{claim_locales}}",
+	"client_assertion_type": "{{client_assertion_type}}",
+	"client_assertion": "{{client_assertion}}",
+    "aud_key": "{{aud_key}}"
+}

--- a/api-test/src/main/resources/esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios.yml
+++ b/api-test/src/main/resources/esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios.yml
@@ -1,0 +1,432 @@
+OauthParNegativeScenarios:
+   ESignet_OauthParNegativeScenarios_Missing_Scope_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_01
+      description: Validate successful PAR request with missing Scope paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "$REMOVE$",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_scope"
+}'
+   ESignet_OauthParNegativeScenarios_Invalid_Scope_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_02
+      description: Validate successful PAR request with invalid Scope paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "7777",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_scope"
+}'
+   ESignet_OauthParNegativeScenarios_Missing_response_type_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_03
+      description: Validate successful PAR request with missing Scope paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "$REMOVE$",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_Invalid_response_type_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_04
+      description: Validate successful PAR request with invalid response_type paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code123",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_Missing_client_id_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_05
+      description: Validate successful PAR request with missing client_id paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$REMOVE$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_Invalid_client_id_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_06
+      description: Validate successful PAR request with invalid client_id paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "esignet99999", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_client_id"
+}'
+   ESignet_OauthParNegativeScenarios_Missing_redirect_uri_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_07
+      description: Validate successful PAR request with missing redirect_uri paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$REMOVE$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_unregistered_redirect_uri_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_08
+      description: Validate successful PAR request with unregistered redirect_uri paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI1234$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_invalid_display_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_09
+      description: Validate successful PAR request with unregistered redirect_uri paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "*",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_invalid_prompt_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_10
+      description: Validate successful PAR request with unregistered redirect_uri paramenter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login1234567",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_invalid_claim_locales_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_11
+      description: Validate successful PAR request with unregistered redirect_uri paramenter
+      role: resident
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/PAR/OauthPar/OauthParResult
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en1234",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+}'
+   ESignet_OauthParNegativeScenarios_invalid_client_assertion_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_12
+      description: Validate successful PAR request with invalid client assertion
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT12345$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_invalid_client_assertion_Type_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_13
+      description: Validate successful PAR request with invalid client assertion type
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bea",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_client"
+}'
+   ESignet_OauthParNegativeScenarios_missing_Client_assertion_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_14
+      description: Validate successful PAR request with Missing client assertion
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "$REMOVE$",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_client"
+}'
+   ESignet_OauthParNegativeScenarios_malformed_Client_assertion_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_15
+      description: Validate successful PAR request with malformed client assertion
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/error2
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "*",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+            "error": "invalid_request"
+}'
+   ESignet_OauthParNegativeScenarios_without_RequestTime_Neg:
+      endPoint: /v1/esignet/oauth/par
+      uniqueIdentifier: TC_ESignet_OauthParNegativeScenarios_16
+      description: Validate successful PAR request without requestTime
+      role: resident
+      restMethod: post
+      checkErrorsOnlyInResponse: true
+      inputTemplate: esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios
+      outputTemplate: esignet/PAR/OauthPar/OauthParResult
+      input: '{
+       "client_id": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$", 
+       "scope": "openid profile",
+       "response_type": "code",
+       "redirect_uri": "$IDPREDIRECTURI$",
+       "display": "popup",
+       "prompt": "login",
+       "acr_values": "mosip:idp:acr:generated-code",
+       "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
+       "state": "eree2311",
+       "claim_locales": "en",
+       "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion": "$CLIENT_ASSERTION_PAR_JWT$",
+       "aud_key": "pushed_authorization_request_endpoint"
+}'
+      output: '{
+}'

--- a/api-test/src/main/resources/esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios.hbs
+++ b/api-test/src/main/resources/esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios.hbs
@@ -1,0 +1,7 @@
+{
+    "requestTime": "{{requestTime}}",
+    "request": {
+        "requestUri": "{{requestUri}}",
+        "clientId": "{{clientId}}"
+    }
+}

--- a/api-test/src/main/resources/esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios.yml
+++ b/api-test/src/main/resources/esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios.yml
@@ -1,0 +1,121 @@
+PAROauthDetailsNegativeScenarios:
+   ESignet_OauthDetailsNegativeScenarios_PAR_AuthToken_Xsrf_missing_ClientId_Neg:
+      endPoint: /v1/esignet/authorization/par-oauth-details
+      uniqueIdentifier: TC_ESignet_PAROauthDetailsNegativeScenarios_01
+      description: Validate successful retrieval of OAuth details in PAR flow with missing clientId in request parameter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios
+      outputTemplate: esignet/error
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "requestUri": "$ID:OauthPar_all_Valid_Smoke_sid_request_uri$",
+       "clientId": "$REMOVE$"
+}'
+      output: '{
+      "errors": [
+    {
+      "errorCode": "invalid_client_id"
+    }
+  ]
+}'
+   ESignet_OauthDetailsNegativeScenarios_PAR_AuthToken_Xsrf_Empty_ClientId_Neg:
+      endPoint: /v1/esignet/authorization/par-oauth-details
+      uniqueIdentifier: TC_ESignet_PAROauthDetailsNegativeScenarios_02
+      description: Validate successful retrieval of OAuth details in PAR flow with Empty clientId in request parameter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios
+      outputTemplate: esignet/error
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "requestUri": "$ID:OauthPar_all_Valid_Smoke_sid_request_uri$",
+       "clientId": " "
+}'
+      output: '{
+      "errors": [
+    {
+      "errorCode": "invalid_client_id"
+    }
+  ]
+}'
+   ESignet_OauthDetailsNegativeScenarios_PAR_AuthToken_Xsrf_invalid_request_method_Neg:
+      endPoint: /v1/esignet/authorization/par-oauth-details
+      uniqueIdentifier: TC_ESignet_PAROauthDetailsNegativeScenarios_03
+      description: Validate successful retrieval of OAuth details in PAR flow with invalid request method
+      role: resident
+      restMethod: put
+      inputTemplate: esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios
+      outputTemplate: esignet/error
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "requestUri": "$ID:OauthPar_all_Valid_Smoke_sid_request_uri$",
+       "clientId": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$"
+}'
+      output: '{
+      "errors": [
+    {
+      "errorCode": "invalid_request"
+    }
+  ]
+}'
+   ESignet_OauthDetailsNegativeScenarios_PAR_AuthToken_Xsrf_invalid_requestURI_Neg:
+      endPoint: /v1/esignet/authorization/par-oauth-details
+      uniqueIdentifier: TC_ESignet_PAROauthDetailsNegativeScenarios_04
+      description: Validate successful retrieval of OAuth details in PAR flow with invalid RequestURI in request parameter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios
+      outputTemplate: esignet/error
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "requestUri": "123456wk31-I0Zx7JRIorYsjfkPB0yQ-4K0tc7LwSzaJ9ft_U",
+       "clientId": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$"
+}'
+      output: '{
+      "errors": [
+    {
+      "errorCode": "invalid_request"
+    }
+  ]
+}'
+   ESignet_OauthDetailsNegativeScenarios_PAR_AuthToken_Xsrf_without_requestURI_Neg:
+      endPoint: /v1/esignet/authorization/par-oauth-details
+      uniqueIdentifier: TC_ESignet_PAROauthDetailsNegativeScenarios_05
+      description: Validate successful retrieval of OAuth details in PAR flow without RequestURI in request parameter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios
+      outputTemplate: esignet/error
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "requestUri": "$REMOVE$",
+       "clientId": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$"
+}'
+      output: '{
+      "errors": [
+    {
+      "errorCode": "invalid_request"
+    }
+  ]
+}'
+   ESignet_OauthDetailsNegativeScenarios_PAR_AuthToken_Xsrf_already_requestURI_Neg:
+      endPoint: /v1/esignet/authorization/par-oauth-details
+      uniqueIdentifier: TC_ESignet_PAROauthDetailsNegativeScenarios_06
+      description: Validate successful retrieval of OAuth details in PAR flow with already used RequestURI in request parameter
+      role: resident
+      restMethod: post
+      inputTemplate: esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios
+      outputTemplate: esignet/error
+      input: '{
+       "requestTime": "$TIMESTAMP$",
+       "requestUri": "$ID:OauthPar_all_Valid_Smoke_sid_request_uri$",
+       "clientId": "$ID:PARCreateOIDCClientV3_all_Valid_Smoke_sid_clientId$"
+}'
+      output: '{
+      "errors": [
+    {
+      "errorCode": "invalid_request"
+    }
+  ]
+}'

--- a/api-test/testNgXmlFiles/esignetSuite.xml
+++ b/api-test/testNgXmlFiles/esignetSuite.xml
@@ -676,6 +676,24 @@
 			<class
 				name="io.mosip.testrig.apirig.esignet.testscripts.GetWithParam" />
 		</classes>
+	</test>
+	<test name="OauthPARNegativeScenarios">
+		<parameter name="ymlFile"
+			value="esignet/PAR/OauthParNegativeScenarios/OauthParNegativeScenarios.yml" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.esignet.testscripts.SimplePostForAutoGenIdForUrlEncoded" />
+		<parameter name="idKeyName" value="request_uri" />				
+		</classes>
+	</test>
+	<test name="PAROauthDetailsNegativeScenarios">
+		<parameter name="ymlFile"
+			value="esignet/PAR/PAROauthDetailsNegativeScenarios/PAROauthDetailsNegativeScenarios.yml" />
+		<parameter name="idKeyName" value="transactionId,encodedResp" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.esignet.testscripts.SimplePostForAutoGenId" />
+		</classes>
 	</test>	
 	<!-- End of end to end v3 with mock flow test cases -->
 


### PR DESCRIPTION
ESignet - Automated the negative test cases for the PAR feature "oauth/par" and "/par-oauth-details" endpoint