### PR TITLE
[MOSIP-43443] added security headers to response

### DIFF
--- a/oidc-ui/nginx/nginx.conf
+++ b/oidc-ui/nginx/nginx.conf
@@ -21,9 +21,6 @@ http {
     gzip_proxied expired no-cache no-store private auth;
     gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
-    add_header Content-Security-Policy "default-src 'none'" always;
-    add_header Referrer-Policy "no-referrer" always;
-
     location /v1/esignet {
       proxy_pass         http://esignet.esignet/v1/esignet;
       proxy_redirect     off;
@@ -31,6 +28,8 @@ http {
       proxy_set_header   X-Real-IP $remote_addr;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Host $server_name;
+      add_header Content-Security-Policy "default-src 'none'" always;
+      add_header Referrer-Policy "no-referrer" always;
     }
     location /.well-known/openid-configuration {
       proxy_pass         http://esignet.esignet/v1/esignet/oidc/.well-known/openid-configuration;
@@ -39,6 +38,8 @@ http {
       proxy_set_header   X-Real-IP $remote_addr;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Host $server_name;
+      add_header Content-Security-Policy "default-src 'none'" always;
+      add_header Referrer-Policy "no-referrer" always;
     }
     location /.well-known/jwks.json {
       proxy_pass         http://esignet.esignet/v1/esignet/oauth/.well-known/jwks.json;
@@ -47,6 +48,8 @@ http {
       proxy_set_header   X-Real-IP $remote_addr;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Host $server_name;
+      add_header Content-Security-Policy "default-src 'none'" always;
+      add_header Referrer-Policy "no-referrer" always;
     }
     location /.well-known/oauth-authorization-server {
       proxy_pass         http://esignet.esignet/v1/esignet/oauth/.well-known/oauth-authorization-server;
@@ -55,6 +58,8 @@ http {
       proxy_set_header   X-Real-IP $remote_addr;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Host $server_name;
+      add_header Content-Security-Policy "default-src 'none'" always;
+      add_header Referrer-Policy "no-referrer" always;
     }
     location /.well-known/openid-credential-issuer {
       proxy_pass         http://esignet.esignet/v1/esignet/vci/.well-known/openid-credential-issuer;
@@ -63,6 +68,8 @@ http {
       proxy_set_header   X-Real-IP $remote_addr;
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Host $server_name;
+      add_header Content-Security-Policy "default-src 'none'" always;
+      add_header Referrer-Policy "no-referrer" always;
     }
     # location /oidc-ui {
     #   alias /usr/share/nginx/oidc-ui;
@@ -71,6 +78,13 @@ http {
     location / {
       # alias /usr/share/nginx/html;
       try_files $uri $uri/ /index.html;
+      add_header Content-Security-Policy "
+          default-src 'self';
+          style-src 'self' https://fonts.googleapis.com;
+          font-src 'self' https://fonts.gstatic.com;
+          img-src 'self' https://cdn.jsdelivr.net
+        " always;
+      add_header Referrer-Policy "no-referrer" always;
     }
   }
 }


### PR DESCRIPTION
As esignet only has rest api endpoints, setting these values for security headers

Content-Security-Policy "default-src 'none'" always;
Referrer-Policy "no-referrer" always;

For oidc-ui adding relevant domains to csp header.