### PR TITLE
Updated base image in DockerFile

### DIFF
--- a/ui-test/Dockerfile
+++ b/ui-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-slim
+FROM eclipse-temurin:11-jre-alpine
 
 USER root
 


### PR DESCRIPTION
Changed the base image from openjdk:21-slim to eclipse-temurin:11-jre-alpineas that image is deprecated.