### PR TITLE
[ES-2777] Always show configuration through actuator/env with some key/values sanitized

### DIFF
--- a/esignet-core/src/main/java/io/mosip/esignet/core/config/ActuatorSanitizationConfig.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/config/ActuatorSanitizationConfig.java
@@ -1,0 +1,31 @@
+package io.mosip.esignet.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.endpoint.SanitizableData;
+import org.springframework.boot.actuate.endpoint.SanitizingFunction;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Custom sanitization rules for Spring Boot Actuator endpoints (e.g. /actuator/env).
+ * Any property whose key matches the configured patterns will have its value masked.
+ */
+@Configuration
+public class ActuatorSanitizationConfig implements SanitizingFunction {
+
+    @Value("#{${mosip.esignet.actuator.sanitize.key.endsWith:{'password','secret','key','token','vcap_services','sun.java.command'}}}")
+    private List<String> keysToBeSanitizedEndsWith;
+
+    @Value("#{${mosip.esignet.actuator.sanitize.key.contains:{'credentials'}}}")
+    private List<String> keysToBeSanitizedContains;
+
+    @Override
+    public SanitizableData apply(SanitizableData data) {
+        String key = data.getKey().toLowerCase(Locale.ROOT);
+        if (keysToBeSanitizedEndsWith.stream().anyMatch(key::endsWith)
+                || keysToBeSanitizedContains.stream().anyMatch(key::contains)) return data.withSanitizedValue();
+        return data;
+    }
+}

--- a/esignet-core/src/main/java/io/mosip/esignet/core/config/ActuatorSanitizationConfig.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/config/ActuatorSanitizationConfig.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package io.mosip.esignet.core.config;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/esignet-core/src/test/java/io/mosip/esignet/core/config/ActuatorSanitizationConfigTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/config/ActuatorSanitizationConfigTest.java
@@ -1,0 +1,66 @@
+package io.mosip.esignet.core.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.endpoint.SanitizableData;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+class ActuatorSanitizationConfigTest {
+
+    private ActuatorSanitizationConfig sanitizingFunction;
+
+    @BeforeEach
+    void setUp() {
+        sanitizingFunction = new ActuatorSanitizationConfig();
+        ReflectionTestUtils.setField(sanitizingFunction, "keysToBeSanitizedEndsWith", List.of("password", "secret"));
+        ReflectionTestUtils.setField(sanitizingFunction, "keysToBeSanitizedContains", List.of("credentials"));
+    }
+
+    @Test
+    void test_sanitizingFunction_endMatch_thenSanitized() {
+        SanitizableData data = mock(SanitizableData.class);
+        SanitizableData sanitizedData = mock(SanitizableData.class);
+
+        when(data.getKey()).thenReturn("db.password");
+        when(data.withSanitizedValue()).thenReturn(sanitizedData);
+
+        SanitizableData result = sanitizingFunction.apply(data);
+
+        assertSame(sanitizedData, result);
+        verify(data).withSanitizedValue();
+        verify(data, atLeastOnce()).getKey();
+    }
+
+    @Test
+    void test_sanitizingFunction_containsMatch_thenSanitized() {
+        SanitizableData data = mock(SanitizableData.class);
+        SanitizableData sanitizedData = mock(SanitizableData.class);
+
+        when(data.getKey()).thenReturn("API_CREDENTIALS_ID");
+        when(data.withSanitizedValue()).thenReturn(sanitizedData);
+
+        SanitizableData result = sanitizingFunction.apply(data);
+
+        assertSame(sanitizedData, result);
+        verify(data).withSanitizedValue();
+        verify(data, atLeastOnce()).getKey();
+    }
+
+    @Test
+    void test_sanitizingFunction_noMatch_thenOriginalData() {
+        SanitizableData data = mock(SanitizableData.class);
+
+        when(data.getKey()).thenReturn("application.name");
+
+        SanitizableData result = sanitizingFunction.apply(data);
+
+        assertSame(data, result);
+        verify(data, never()).withSanitizedValue();
+        verify(data, atLeastOnce()).getKey();
+    }
+}

--- a/esignet-core/src/test/java/io/mosip/esignet/core/config/ActuatorSanitizationConfigTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/config/ActuatorSanitizationConfigTest.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package io.mosip.esignet.core.config;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/esignet-service/src/main/resources/bootstrap.properties
+++ b/esignet-service/src/main/resources/bootstrap.properties
@@ -41,6 +41,7 @@ management.endpoint.metrics.access=read-only
 management.endpoints.web.exposure.include=*
 management.endpoint.prometheus.access=read-only
 management.prometheus.metrics.export.enabled=true
+management.endpoint.env.show-values=ALWAYS
 
 # disable mapping unknown endpoints to static resources instead throw exception
 spring.web.resources.add-mappings=false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic masking of sensitive values exposed by monitoring endpoints; common secrets, passwords and credential-like values are now protected.

* **Chores**
  * Added property to control environment value visibility in monitoring tools (enables showing env values when configured).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->