### PR TITLE
[ES-2454] Not able to update signup-client without empty userClaims - Fixed

### DIFF
--- a/esignet-core/src/main/java/io/mosip/esignet/core/dto/ClientDetailUpdateRequest.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/dto/ClientDetailUpdateRequest.java
@@ -30,7 +30,7 @@ public class ClientDetailUpdateRequest {
                  @RedirectURL String> redirectUris;
 
     @NotNull(message = ErrorConstants.INVALID_CLAIM)
-    @Size(message = ErrorConstants.INVALID_CLAIM, min = 1, max = 30)
+    @Size(message = ErrorConstants.INVALID_CLAIM, max = 30)
     private List<@OIDCClaim String> userClaims;
 
     @NotNull(message = ErrorConstants.INVALID_ACR)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed validation requirements on client detail updates to allow submissions with zero user claims, while preserving the maximum threshold of 30 claims.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->