### PR TITLE
MOSIP-43936: Support RunContext Prefix for eSignet Parallel Execution by Updating Module Checks

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/esignet/testscripts/EsignetBioAuth.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/esignet/testscripts/EsignetBioAuth.java
@@ -86,7 +86,7 @@ public class EsignetBioAuth extends EsignetUtil implements ITest {
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();		
-		if (BaseTestCase.currentModule.equals(GlobalConstants.MASTERDATA)== false) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.MASTERDATA)== false) {
 			testCaseName = EsignetUtil.isTestCaseValidForExecution(testCaseDTO);
 		}
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/esignet/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/esignet/testscripts/SimplePostForAutoGenId.java
@@ -105,8 +105,8 @@ public class SimplePostForAutoGenId extends EsignetUtil implements ITest {
 		String[] templateFields = testCaseDTO.getTemplateFields();
 		String inputJson = "";
 
-		if ((BaseTestCase.currentModule.equals(GlobalConstants.MASTERDATA)
-				|| BaseTestCase.currentModule.equals(EsignetConstants.DSL))
+		if ((BaseTestCase.currentModule.contains(GlobalConstants.MASTERDATA)
+				|| BaseTestCase.currentModule.contains(EsignetConstants.DSL))
 				&& testCaseName.startsWith("Esignet_CreateOIDCClient")) {
 			inputJson = testCaseDTO.getInput();
 		} else {


### PR DESCRIPTION
- Replaced equals() with contains() for BaseTestCase.currentModule checks in eSignet test scripts.
- Updated MASTERDATA and DSL module comparisons to work correctly when runContext/module names are prefixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Updated test execution logic to use substring matching instead of exact matching for test case gating conditions, expanding test coverage and input processing scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->