### PR TITLE
[ES-2843] fixed: pkce validation error codes

### DIFF
--- a/docs/esignet-openapi.yaml
+++ b/docs/esignet-openapi.yaml
@@ -5046,10 +5046,9 @@ paths:
                       - invalid_input
                       - unknown_error
                       - invalid_request
+                      - invalid_grant
                       - invalid_assertion_type
-                      - invalid_pkce_code_verifier
                       - unsupported_pkce_challenge_method
-                      - pkce_failed
                       - invalid_dpop_proof
                       - use_dpop_nonce
                     description: The error code.

--- a/esignet-core/src/main/java/io/mosip/esignet/core/constants/ErrorConstants.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/constants/ErrorConstants.java
@@ -46,7 +46,6 @@ public class ErrorConstants {
     public static final String INVALID_AUTH_FACTOR_TYPE="invalid_auth_factor_type";
     public static final String INVALID_CHALLENGE="invalid_challenge";
     public static final String INVALID_STATUS = "invalid_status";
-    public static final String INVALID_AUTH_CODE = "invalid_auth_code";
     public static final String INVALID_ID_TOKEN_HINT= "invalid_id_token_hint";
     public static final String AUTH_FACTOR_MISMATCH = "auth_factor_mismatch";
     public static final String UNSUPPORTED_ID_FORMAT = "unsupported_id_format";
@@ -74,8 +73,6 @@ public class ErrorConstants {
     public static final String INVALID_AUTH_FACTOR_TYPE_OR_CHALLENGE_FORMAT = "invalid_auth_factor_type_or_challenge_format";
     public static final String UNSUPPORTED_PKCE_CHALLENGE_METHOD = "unsupported_pkce_challenge_method";
     public static final String INVALID_PKCE_CHALLENGE = "invalid_pkce_challenge";
-    public static final String INVALID_PKCE_CODE_VERFIER = "invalid_pkce_code_verifier";
-    public static final String PKCE_FAILED = "pkce_failed";
     public static final String NO_ATTEMPTS_LEFT = "no_attempts_left";
     public static final String INDIVIDUAL_ID_BLOCKED = "individual_id_blocked";
     public static final String TOO_EARLY_ATTEMPT = "too_early_attempt";

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
@@ -247,7 +247,7 @@ public class OAuthServiceImpl implements OAuthService {
 
         if(ObjectUtils.isEmpty(codeVerifier)) {
             log.error("Null or empty code_verifier found in the request");
-            throw new EsignetException(ErrorConstants.INVALID_PKCE_CODE_VERFIER);
+            throw new EsignetException(ErrorConstants.INVALID_GRANT);
         }
 
         String computedChallenge;
@@ -260,8 +260,10 @@ public class OAuthServiceImpl implements OAuthService {
                 throw new EsignetException(ErrorConstants.UNSUPPORTED_PKCE_CHALLENGE_METHOD);
         }
 
-        if(ObjectUtils.isEmpty(computedChallenge) || !computedChallenge.equals(proofKeyCodeExchange.getCodeChallenge()))
-            throw new EsignetException(ErrorConstants.PKCE_FAILED);
+        if(ObjectUtils.isEmpty(computedChallenge) || !computedChallenge.equals(proofKeyCodeExchange.getCodeChallenge())) {
+            log.error("PKCE validation failed, code_verifier did not match with code_challenge");
+            throw new EsignetException(ErrorConstants.INVALID_GRANT);
+        }
     }
 
     private TokenResponse getTokenResponse(OIDCTransaction transaction, boolean isTransactionVCScoped) {

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/OAuthServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/OAuthServiceTest.java
@@ -486,7 +486,7 @@ public class OAuthServiceTest {
         try {
             oAuthService.getTokens(tokenRequest, null, false);
         } catch (EsignetException ex) {
-            Assertions.assertEquals(INVALID_PKCE_CODE_VERFIER, ex.getErrorCode());
+            Assertions.assertEquals(INVALID_GRANT, ex.getErrorCode());
         }
     }
 
@@ -628,7 +628,7 @@ public class OAuthServiceTest {
             oAuthService.getTokens(tokenRequest, null, true);
             Assertions.fail();
         } catch (EsignetException ex) {
-            Assertions.assertEquals(PKCE_FAILED, ex.getErrorCode());
+            Assertions.assertEquals(INVALID_GRANT, ex.getErrorCode());
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized PKCE-related error responses so OAuth token requests now return a single, consistent error code for PKCE failures.

* **Documentation**
  * API specification updated to reflect the revised set of token endpoint error codes.

* **Tests**
  * Test expectations updated to align with the new standardized error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->