### PR TITLE
[ES-2831] Update Redis host configuration in docker-compose

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - MOSIP_ESIGNET_MOCK_DOMAIN_URL=http://mock-identity-system:8082
       - MOSIP_ESIGNET_INTEGRATION_KEY_BINDER=MockKeyBindingWrapperService
       - SPRING_CACHE_TYPE=redis
-      - SPRING_REDIS_HOST=redis-server
+      - SPRING_DATA_REDIS_HOST=redis-server
       - SPRING_REDIS_PASSWORD=
       - KAFKA_ENABLED=false
       - SPRING_AUTOCONFIGURE_EXCLUDE=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration to ensure proper Redis service connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->