### PR TITLE
[ES-2838] changed exception code to give correct error response

### DIFF
--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/OAuthServiceImpl.java
@@ -231,7 +231,7 @@ public class OAuthServiceImpl implements OAuthService {
             throw new EsignetException(ErrorConstants.INVALID_GRANT);
 
         if (StringUtils.hasText(tokenRequest.getClient_id()) && !transaction.getClientId().equals(tokenRequest.getClient_id()))
-            throw new EsignetException(ErrorConstants.INVALID_CLIENT_ID);
+            throw new EsignetException(ErrorConstants.INVALID_CLIENT);
 
         if (!transaction.getRedirectUri().equals(tokenRequest.getRedirect_uri()))
             throw new EsignetException(ErrorConstants.INVALID_REDIRECT_URI);

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/OAuthServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/OAuthServiceTest.java
@@ -418,7 +418,7 @@ public class OAuthServiceTest {
         Mockito.when(cacheUtilService.getAuthCodeTransaction(Mockito.anyString())).thenReturn(oidcTransaction);
 
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> oAuthService.getTokens(tokenRequest, null, false));
-        Assertions.assertEquals(INVALID_CLIENT_ID, ex.getErrorCode());
+        Assertions.assertEquals(INVALID_CLIENT, ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the error code returned when client authentication validation fails during transaction processing from INVALID_CLIENT_ID to INVALID_CLIENT; corresponding test expectations updated for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->