### PR TITLE
ES-2842 | increased the leeway seconds to 15

### DIFF
--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -451,7 +451,7 @@ mosip.esignet.ui.config.key-values={'sbi.env': '${mosip.esignet.authenticator.id
 
 
 # leeway given in verfication of client assertion: exp and nbf field
-mosip.esignet.client-assertion-jwt.leeway-seconds=5
+mosip.esignet.client-assertion-jwt.leeway-seconds=15
 
 mosip.esignet.client-assertion.unique.jti.required=true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased JWT validation leeway for client assertions from 5 to 15 seconds, enhancing flexibility in timing validation during client authentication processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->