### PR TITLE
[ES-2839] bug fix for invalid code returned

### DIFF
--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/TokenServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/TokenServiceImpl.java
@@ -192,8 +192,8 @@ public class TokenServiceImpl implements TokenService {
             }
         } catch (Exception e) {
             log.error("Failed to verify client assertion", e);
-            if (e instanceof EsignetException) {
-                throw (EsignetException) e;
+            if (e instanceof EsignetException esignetException) {
+                throw esignetException;
             }
             throw new EsignetException(ErrorConstants.INVALID_CLIENT);
         }

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/TokenServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/TokenServiceImpl.java
@@ -190,11 +190,10 @@ public class TokenServiceImpl implements TokenService {
                 log.error("invalid jti {}", jti);
                 throw new EsignetException(ErrorConstants.INVALID_CLIENT);
             }
+        } catch (EsignetException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Failed to verify client assertion", e);
-            if (e instanceof EsignetException esignetException) {
-                throw esignetException;
-            }
             throw new EsignetException(ErrorConstants.INVALID_CLIENT);
         }
     }

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/TokenServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/TokenServiceImpl.java
@@ -174,7 +174,7 @@ public class TokenServiceImpl implements TokenService {
 
             if (alg == null || !supportedAlgs.contains(alg)) {
                 log.error("Invalid or unsupported alg header: {}", alg);
-                throw new EsignetException(ErrorConstants.INVALID_CLIENT);
+                throw new EsignetException();
             }
 
             NimbusJwtDecoder jwtDecoder = getNimbusJwtDecoderFromJwk(jwk, clientId, audience, maxClockSkew, alg);
@@ -186,7 +186,7 @@ public class TokenServiceImpl implements TokenService {
             }
         } catch (Exception e) {
             log.error("Failed to verify client assertion", e);
-            throw new EsignetException(ErrorConstants.INVALID_CLIENT);
+            throw new EsignetException(ErrorConstants.INVALID_GRANT);
         }
     }
 

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/TokenServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/TokenServiceImpl.java
@@ -174,7 +174,13 @@ public class TokenServiceImpl implements TokenService {
 
             if (alg == null || !supportedAlgs.contains(alg)) {
                 log.error("Invalid or unsupported alg header: {}", alg);
-                throw new EsignetException();
+                throw new EsignetException(ErrorConstants.INVALID_CLIENT);
+            }
+
+            String sub = signedJWT.getJWTClaimsSet().getSubject();
+            if (sub == null || !sub.equals(clientId)) {
+                log.error("Client assertion sub '{}' does not match clientId '{}'", sub, clientId);
+                throw new EsignetException(ErrorConstants.INVALID_GRANT);
             }
 
             NimbusJwtDecoder jwtDecoder = getNimbusJwtDecoderFromJwk(jwk, clientId, audience, maxClockSkew, alg);
@@ -182,11 +188,14 @@ public class TokenServiceImpl implements TokenService {
             String jti = signedJWT.getJWTClaimsSet().getJWTID();
             if (uniqueJtiRequired && (jti == null || cacheUtilService.checkAndMarkJti(jti))) {
                 log.error("invalid jti {}", jti);
-                throw new EsignetException();
+                throw new EsignetException(ErrorConstants.INVALID_CLIENT);
             }
         } catch (Exception e) {
             log.error("Failed to verify client assertion", e);
-            throw new EsignetException(ErrorConstants.INVALID_GRANT);
+            if (e instanceof EsignetException) {
+                throw (EsignetException) e;
+            }
+            throw new EsignetException(ErrorConstants.INVALID_CLIENT);
         }
     }
 

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/TokenServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/TokenServiceTest.java
@@ -186,7 +186,7 @@ public class TokenServiceTest {
         SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), claimsSet);
         jwt.sign(signer);
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), jwt.serialize(), List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
     }
 
     @Test
@@ -202,7 +202,7 @@ public class TokenServiceTest {
         SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), claimsSet);
         jwt.sign(signer);
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), jwt.serialize(), List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
     }
 
     @Test
@@ -270,7 +270,7 @@ public class TokenServiceTest {
                 jwt.serialize(),
                 List.of("tokenendpoint")
         ));
-        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
     }
 
     @Test
@@ -282,7 +282,7 @@ public class TokenServiceTest {
     @Test
     public void verifyClientAssertionToken_withInvalidToken_thenFail() {
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), "client-assertion", List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
     }
 
     @Test
@@ -318,7 +318,7 @@ public class TokenServiceTest {
         signedJWT.sign(signer);
         Mockito.when(cacheUtilService.checkAndMarkJti(Mockito.anyString())).thenReturn(true);
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", rsaKey.toJSONString(), signedJWT.serialize(), List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
     }
 
     @Test
@@ -380,7 +380,7 @@ public class TokenServiceTest {
         SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.PS384), claimsSet);
         jwt.sign(signer);
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), jwt.serialize(), List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
     }
 
     @Test
@@ -397,7 +397,7 @@ public class TokenServiceTest {
         String encodedPayload = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
         String malformedJwt = encodedHeader + "." + encodedPayload + "." + "dummySignature";
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), malformedJwt, List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
     }
 
     @Test
@@ -419,6 +419,80 @@ public class TokenServiceTest {
     public void verifyAccessToken_withInvalidDataToken_thenFail() {
         assertThrows(NotAuthenticatedException.class, () ->
                 tokenService.verifyAccessToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkJhZWxkdW5nIFVzZXIiLCJpYXQiOjE1MTYyMzkwMjJ9.qH7Zj_m3kY69kxhaQXTa-ivIpytKXXjZc1ZSmapZnGE"));
+    }
+
+    @Test
+    public void verifyClientAssertion_withNullSubject_thenFail() throws Exception {
+        RSAKey rsaKey = new RSAKeyGenerator(2048)
+                .algorithm(JWSAlgorithm.RS256)
+                .keyID("rsa-rs256")
+                .generate();
+
+        JWSSigner signer = new RSASSASigner(rsaKey);
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .issuer("client-id")
+                .audience("audience")
+                .issueTime(new Date(123000L))
+                .expirationTime(new Date(System.currentTimeMillis() + 60000))
+                .jwtID(IdentityProviderUtil.createTransactionId(null))
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaKey.getKeyID()).build(), claimsSet);
+        signedJWT.sign(signer);
+
+        EsignetException ex = Assertions.assertThrows(EsignetException.class, () ->
+                tokenService.verifyClientAssertionToken("client-id", rsaKey.toPublicJWK().toJSONString(), signedJWT.serialize(), List.of("audience")));
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+    }
+
+    @Test
+    public void verifyClientAssertion_withMismatchedSubject_thenFail() throws Exception {
+        RSAKey rsaKey = new RSAKeyGenerator(2048)
+                .algorithm(JWSAlgorithm.RS256)
+                .keyID("rsa-rs256")
+                .generate();
+
+        JWSSigner signer = new RSASSASigner(rsaKey);
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .subject("different-client-id")
+                .issuer("client-id")
+                .audience("audience")
+                .issueTime(new Date(123000L))
+                .expirationTime(new Date(System.currentTimeMillis() + 60000))
+                .jwtID(IdentityProviderUtil.createTransactionId(null))
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaKey.getKeyID()).build(), claimsSet);
+        signedJWT.sign(signer);
+
+        EsignetException ex = Assertions.assertThrows(EsignetException.class, () ->
+                tokenService.verifyClientAssertionToken("client-id", rsaKey.toPublicJWK().toJSONString(), signedJWT.serialize(), List.of("audience")));
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
+    }
+
+    @Test
+    public void verifyClientAssertion_withEmptySubject_thenFail() throws Exception {
+        RSAKey rsaKey = new RSAKeyGenerator(2048)
+                .algorithm(JWSAlgorithm.RS256)
+                .keyID("rsa-rs256")
+                .generate();
+
+        JWSSigner signer = new RSASSASigner(rsaKey);
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .subject("")
+                .issuer("client-id")
+                .audience("audience")
+                .issueTime(new Date(123000L))
+                .expirationTime(new Date(System.currentTimeMillis() + 60000))
+                .jwtID(IdentityProviderUtil.createTransactionId(null))
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaKey.getKeyID()).build(), claimsSet);
+        signedJWT.sign(signer);
+
+        EsignetException ex = Assertions.assertThrows(EsignetException.class, () ->
+                tokenService.verifyClientAssertionToken("client-id", rsaKey.toPublicJWK().toJSONString(), signedJWT.serialize(), List.of("audience")));
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
     }
 
     @Test

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/TokenServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/TokenServiceTest.java
@@ -186,7 +186,7 @@ public class TokenServiceTest {
         SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), claimsSet);
         jwt.sign(signer);
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), jwt.serialize(), List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
     }
 
     @Test
@@ -202,7 +202,7 @@ public class TokenServiceTest {
         SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), claimsSet);
         jwt.sign(signer);
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), jwt.serialize(), List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
     }
 
     @Test
@@ -270,7 +270,7 @@ public class TokenServiceTest {
                 jwt.serialize(),
                 List.of("tokenendpoint")
         ));
-        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
     }
 
     @Test
@@ -282,7 +282,7 @@ public class TokenServiceTest {
     @Test
     public void verifyClientAssertionToken_withInvalidToken_thenFail() {
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), "client-assertion", List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
     }
 
     @Test
@@ -318,7 +318,7 @@ public class TokenServiceTest {
         signedJWT.sign(signer);
         Mockito.when(cacheUtilService.checkAndMarkJti(Mockito.anyString())).thenReturn(true);
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", rsaKey.toJSONString(), signedJWT.serialize(), List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
     }
 
     @Test
@@ -380,7 +380,7 @@ public class TokenServiceTest {
         SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.PS384), claimsSet);
         jwt.sign(signer);
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), jwt.serialize(), List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
     }
 
     @Test
@@ -397,7 +397,7 @@ public class TokenServiceTest {
         String encodedPayload = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
         String malformedJwt = encodedHeader + "." + encodedPayload + "." + "dummySignature";
         EsignetException ex = Assertions.assertThrows(EsignetException.class, () -> tokenService.verifyClientAssertionToken("client-id", RSA_JWK.toPublicJWK().toJSONString(), malformedJwt, List.of("audience")));
-        Assertions.assertEquals(ErrorConstants.INVALID_CLIENT, ex.getErrorCode());
+        Assertions.assertEquals(ErrorConstants.INVALID_GRANT, ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token verification now requires the token subject to match the client ID and returns more specific error responses for subject mismatches, invalid/duplicate identifiers, and unsupported or malformed tokens.

* **Tests**
  * Added negative tests for null, empty, and mismatched token subjects to validate the refined verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->