### PR TITLE
ES-2851 | Fix prompt=none handling for unauthenticated users

### DIFF
--- a/esignet-core/src/main/java/io/mosip/esignet/core/constants/Constants.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/constants/Constants.java
@@ -66,4 +66,5 @@ public class Constants {
     public static final String REQUIRE_PAR= "require_pushed_authorization_requests";
     public static final String REQUIRE_PKCE= "require_pkce";
     public static final String NONE= "none";
+    public static final String LOGIN = "login";
 }

--- a/esignet-core/src/main/java/io/mosip/esignet/core/constants/ErrorConstants.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/constants/ErrorConstants.java
@@ -85,4 +85,5 @@ public class ErrorConstants {
     public static final String INVALID_DPOP_PROOF = "invalid_dpop_proof";
     public static final String USE_DPOP_NONCE = "use_dpop_nonce";
     public static final String USE_PKCE = "use_pkce";
+    public static final String LOGIN_REQUIRED = "login_required";
 }

--- a/esignet-core/src/main/java/io/mosip/esignet/core/validator/OIDCPrompt.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/validator/OIDCPrompt.java
@@ -6,23 +6,21 @@
 package io.mosip.esignet.core.validator;
 
 import io.mosip.esignet.core.constants.ErrorConstants;
-
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Target({ FIELD })
+@Target({FIELD})
 @Retention(RUNTIME)
 @Constraint(validatedBy = OIDCPromptValidator.class)
 @Documented
 public @interface OIDCPrompt {
 
-    String message() default ErrorConstants.INVALID_PROMPT;
+    String message() default ErrorConstants.LOGIN_REQUIRED;
 
     Class<?>[] groups() default {};
 

--- a/esignet-core/src/main/java/io/mosip/esignet/core/validator/OIDCPromptValidator.java
+++ b/esignet-core/src/main/java/io/mosip/esignet/core/validator/OIDCPromptValidator.java
@@ -5,9 +5,9 @@
  */
 package io.mosip.esignet.core.validator;
 
+import io.mosip.esignet.core.constants.Constants;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.List;
@@ -20,9 +20,19 @@ public class OIDCPromptValidator implements ConstraintValidator<OIDCPrompt, Stri
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        if(value == null)
+        if (value == null || value.trim().isEmpty())
             return true; // As this is OPTIONAL parameter
 
-        return supportedPrompts.contains(value);
+        // Split by space and trim each token
+        String[] promptTokens = value.trim().split("\\s+");
+
+        // reject if any token is none/login
+        for (String token : promptTokens) {
+            if (Constants.NONE.equals(token) || Constants.LOGIN.equals(token)) {
+                return false; // → login_required
+            }
+        }
+
+        return true;
     }
 }

--- a/esignet-core/src/test/java/io/mosip/esignet/core/ValidatorTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/ValidatorTest.java
@@ -171,36 +171,57 @@ public class ValidatorTest {
     @Test
     public void test_PromptValidator_valid_thenPass() {
         OIDCPromptValidator validator = new OIDCPromptValidator();
-        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("none", "login", "consent"));
+        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
         Assertions.assertTrue(validator.isValid("consent", null));
     }
 
     @Test
     public void test_PromptValidator_invalid_thenFail() {
         OIDCPromptValidator validator = new OIDCPromptValidator();
-        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("none", "login", "consent"));
-        Assertions.assertFalse(validator.isValid("pop-up", null));
+        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
+        Assertions.assertTrue(validator.isValid("pop-up", null));
     }
 
     @Test
     public void test_PromptValidator_invalidWithSpace_thenFail() {
         OIDCPromptValidator validator = new OIDCPromptValidator();
-        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("none", "login", "consent"));
+        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
         Assertions.assertFalse(validator.isValid(" login ", null));
+    }
+
+    @Test
+    public void test_PromptValidator_none_thenFail() {
+        OIDCPromptValidator validator = new OIDCPromptValidator();
+        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
+        Assertions.assertFalse(validator.isValid("none", null));
+    }
+
+    @Test
+    public void test_PromptValidator_login_thenFail() {
+        OIDCPromptValidator validator = new OIDCPromptValidator();
+        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
+        Assertions.assertFalse(validator.isValid("login", null));
+    }
+
+    @Test
+    public void test_PromptValidator_spaceDelimitedWithLogin_thenFail() {
+        OIDCPromptValidator validator = new OIDCPromptValidator();
+        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
+        Assertions.assertFalse(validator.isValid("consent login", null));
     }
 
     @Test
     public void test_PromptValidator_nullValue_thenPass() {
         OIDCPromptValidator validator = new OIDCPromptValidator();
-        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("none", "login", "consent"));
+        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
         Assertions.assertTrue(validator.isValid(null, null));
     }
 
     @Test
-    public void test_PromptValidator_EmptyValue_thenFail() {
+    public void test_PromptValidator_EmptyValue_thenPass() {
         OIDCPromptValidator validator = new OIDCPromptValidator();
         ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("none", "login", "consent"));
-        Assertions.assertFalse(validator.isValid("", null));
+        Assertions.assertTrue(validator.isValid("", null));
     }
 
     // ============================ ResponseType Validator =========================

--- a/esignet-core/src/test/java/io/mosip/esignet/core/ValidatorTest.java
+++ b/esignet-core/src/test/java/io/mosip/esignet/core/ValidatorTest.java
@@ -183,24 +183,31 @@ public class ValidatorTest {
     }
 
     @Test
-    public void test_PromptValidator_invalidWithSpace_thenFail() {
+    public void test_PromptValidator_WithSpace_thenFail() {
         OIDCPromptValidator validator = new OIDCPromptValidator();
         ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
         Assertions.assertFalse(validator.isValid(" login ", null));
     }
 
     @Test
-    public void test_PromptValidator_none_thenFail() {
+    public void test_PromptValidator_Withnone_thenFail() {
         OIDCPromptValidator validator = new OIDCPromptValidator();
         ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
         Assertions.assertFalse(validator.isValid("none", null));
     }
 
     @Test
-    public void test_PromptValidator_login_thenFail() {
+    public void test_PromptValidator_Withlogin_thenFail() {
         OIDCPromptValidator validator = new OIDCPromptValidator();
         ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
         Assertions.assertFalse(validator.isValid("login", null));
+    }
+
+    @Test
+    public void test_PromptValidator_withSelectAccount_thenPass() {
+        OIDCPromptValidator validator = new OIDCPromptValidator();
+        ReflectionTestUtils.setField(validator, "supportedPrompts", Arrays.asList("consent"));
+        Assertions.assertTrue(validator.isValid("select_account", null));
     }
 
     @Test

--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -151,21 +151,16 @@ mosip.esignet.supported.grant.types={'authorization_code'}
 # wap-The Authorization Server SHOULD display the authentication and consent UI consistent with a "feature phone" type display.
 mosip.esignet.supported.ui.displays={'page','popup','touch','wap'}
 
-## specifies whether the Authorization Server prompts the End-User for reauthentication and consent
-# none-The Authorization Server MUST NOT display any authentication or consent user interface pages.
-# An error is returned if an End-User is not already authenticated or the Client does not have pre-configured consent
-# for the requested Claims or does not fulfill other conditions for processing the request.
-# The error code will typically be login_required, interaction_required, or another code defined in Section 3.1.2.6.
-# This can be used as a method to check for existing authentication and/or consent.
-# login-The Authorization Server SHOULD prompt the End-User for reauthentication. If it cannot reauthenticate the End-User, \
-#  it MUST return an error, typically login_required.
-# consent-The Authorization Server SHOULD prompt the End-User for consent before returning information to the Client.
-# If it cannot obtain consent, it MUST return an error, typically consent_required.
-# select_account-The Authorization Server SHOULD prompt the End-User to select a user account. This enables an End-User
-# who has multiple accounts at the Authorization Server to select amongst the multiple accounts that they might have current
-# sessions for. If it cannot obtain an account selection choice made by the End-User, it MUST return an error,
-# typically account_selection_required.
-mosip.esignet.supported.ui.prompts={'none','login','consent','select_account'}
+## Specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
+## Supported values:
+# consent - The Authorization Server prompts the End-User for consent before returning information to the Client.
+#           If it cannot obtain consent, it MUST return an error, typically consent_required.
+## Unsupported values (returns login_required error):
+# none    - Silent authentication is not supported. login_required error will be returned.
+# login   - Reauthentication is not supported. login_required error will be returned.
+## Ignored values (unknown/unrecognized prompt values are ignored per OIDC spec section 3.1.2.1):
+# select_account - Not supported, ignored.
+mosip.esignet.supported.ui.prompts={'consent'}
 
 ## Type of the client assertion
 mosip.esignet.supported.client.assertion.types={'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'}

--- a/esignet-service/src/test/java/io/mosip/esignet/controllers/AuthorizationControllerTest.java
+++ b/esignet-service/src/test/java/io/mosip/esignet/controllers/AuthorizationControllerTest.java
@@ -138,7 +138,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setRedirectUri("https://localhost:9090/v1/idp");
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
 
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
@@ -165,7 +165,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setRedirectUri(" ");
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -190,7 +190,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code level2");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -219,7 +219,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("none");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -237,7 +237,7 @@ public class AuthorizationControllerTest {
     }
 
     @Test
-    public void getOauthDetails_withInvalidPrompt_returnErrorResponse() throws Exception {
+    public void getOauthDetails_withInvalidPrompt_returnSuccessResponse() throws Exception {
         OAuthDetailRequest oauthDetailRequest = new OAuthDetailRequest();
         oauthDetailRequest.setClientId("12345");
         oauthDetailRequest.setRedirectUri("https://localhost:9090/v1/idp");
@@ -253,12 +253,16 @@ public class AuthorizationControllerTest {
         wrapper.setRequestTime(requestTime.format(DateTimeFormatter.ofPattern(UTC_DATETIME_PATTERN)));
         wrapper.setRequest(oauthDetailRequest);
 
+        OAuthDetailResponseV1 oauthDetailResponse = new OAuthDetailResponseV1();
+        oauthDetailResponse.setTransactionId("qwertyId");
+        when(authorizationService.getOauthDetails(oauthDetailRequest)).thenReturn(oauthDetailResponse);
+
         mockMvc.perform(post("/authorization/oauth-details")
                         .content(objectMapper.writeValueAsString(wrapper))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errors").isNotEmpty())
-                .andExpect(jsonPath("$.errors[0].errorCode").value(ErrorConstants.INVALID_PROMPT));
+                .andExpect(jsonPath("$.errors").isEmpty())
+                .andExpect(jsonPath("$.response.transactionId").value("qwertyId"));
     }
 
     @Test
@@ -269,7 +273,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("none");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("implicit");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -294,7 +298,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -322,7 +326,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("profile");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -347,7 +351,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("profile openid");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -375,7 +379,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("resident-service");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -403,7 +407,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid resident-service");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -446,7 +450,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setRedirectUri("https://localhost:9090/v1/idp");
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
 
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
@@ -482,7 +486,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setRedirectUri(" ");
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -514,7 +518,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code level2");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -549,7 +553,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setDisplay("page");
         oauthDetailRequest.setRedirectUri("https://localhost:9090/v1/idp");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setCodeChallenge("123");
@@ -582,7 +586,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setDisplay("page");
         oauthDetailRequest.setRedirectUri("https://localhost:9090/v1/idp");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setCodeChallenge("123");
@@ -617,7 +621,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("none");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -642,7 +646,7 @@ public class AuthorizationControllerTest {
     }
 
     @Test
-    public void getOauthDetailsV2_withInvalidPrompt_returnErrorResponse() throws Exception {
+    public void getOauthDetailsV2_withInvalidPrompt_returnSuccessResponse() throws Exception {
         OAuthDetailRequest oauthDetailRequest = new OAuthDetailRequest();
         oauthDetailRequest.setClientId("12345");
         oauthDetailRequest.setRedirectUri("https://localhost:9090/v1/idp");
@@ -658,19 +662,24 @@ public class AuthorizationControllerTest {
         wrapper.setRequestTime(requestTime.format(DateTimeFormatter.ofPattern(UTC_DATETIME_PATTERN)));
         wrapper.setRequest(oauthDetailRequest);
 
+        OAuthDetailResponseV2 oauthDetailResponseV2 = new OAuthDetailResponseV2();
+        oauthDetailResponseV2.setTransactionId("qwertyId");
+        when(authorizationService.getOauthDetailsV2(Mockito.any())).thenReturn(oauthDetailResponseV2);
+
         mockMvc.perform(post("/authorization/v2/oauth-details")
                         .content(objectMapper.writeValueAsString(wrapper))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errors").isNotEmpty())
-                .andExpect(jsonPath("$.errors[0].errorCode").value(ErrorConstants.INVALID_PROMPT));
+                .andExpect(jsonPath("$.errors").isEmpty())
+                .andExpect(jsonPath("$.response.transactionId").value("qwertyId"));
 
+        when(authorizationService.getOauthDetailsV3(Mockito.any(), Mockito.any())).thenReturn(oauthDetailResponseV2);
         mockMvc.perform(post("/authorization/v3/oauth-details")
                         .content(objectMapper.writeValueAsString(wrapper))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errors").isNotEmpty())
-                .andExpect(jsonPath("$.errors[0].errorCode").value(ErrorConstants.INVALID_PROMPT));
+                .andExpect(jsonPath("$.errors").isEmpty())
+                .andExpect(jsonPath("$.response.transactionId").value("qwertyId"));
     }
 
     @Test
@@ -681,7 +690,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid profile");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("none");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("implicit");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -713,7 +722,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -748,7 +757,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("profile");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -780,7 +789,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("profile openid");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -815,7 +824,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("resident-service");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);
@@ -850,7 +859,7 @@ public class AuthorizationControllerTest {
         oauthDetailRequest.setScope("openid resident-service");
         oauthDetailRequest.setAcrValues("mosip:idp:acr:static-code");
         oauthDetailRequest.setDisplay("page");
-        oauthDetailRequest.setPrompt("login");
+        oauthDetailRequest.setPrompt("consent");
         oauthDetailRequest.setResponseType("code");
         oauthDetailRequest.setNonce("23424234TY");
         oauthDetailRequest.setClaims(claimsV2);

--- a/esignet-service/src/test/java/io/mosip/esignet/flows/AuthCodeFlowTest.java
+++ b/esignet-service/src/test/java/io/mosip/esignet/flows/AuthCodeFlowTest.java
@@ -301,7 +301,7 @@ public class AuthCodeFlowTest {
         oAuthDetailRequest.setClientId(clientId);
         oAuthDetailRequest.setRedirectUri(redirectionUrl);
         oAuthDetailRequest.setAcrValues("level0 mosip:idp:acr:static-code");
-        oAuthDetailRequest.setPrompt("login");
+        oAuthDetailRequest.setPrompt("consent");
         oAuthDetailRequest.setDisplay("popup");
         oAuthDetailRequest.setScope("openid profile");
         oAuthDetailRequest.setResponseType("code");

--- a/esignet-service/src/test/java/io/mosip/esignet/flows/AuthorizationAPIFlowTest.java
+++ b/esignet-service/src/test/java/io/mosip/esignet/flows/AuthorizationAPIFlowTest.java
@@ -426,7 +426,7 @@ public class AuthorizationAPIFlowTest {
         oAuthDetailRequest.setClientId(clientId);
         oAuthDetailRequest.setRedirectUri(redirectionUrl);
         oAuthDetailRequest.setAcrValues("level0 mosip:idp:acr:static-code");
-        oAuthDetailRequest.setPrompt("login");
+        oAuthDetailRequest.setPrompt("consent");
         oAuthDetailRequest.setDisplay("popup");
         oAuthDetailRequest.setScope("openid profile");
         oAuthDetailRequest.setResponseType("code");

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
@@ -25,7 +25,6 @@ import io.mosip.esignet.core.spi.AuthorizationService;
 import io.mosip.esignet.core.spi.ClientManagementService;
 import io.mosip.esignet.core.spi.TokenService;
 import io.mosip.esignet.core.util.*;
-import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -168,13 +167,6 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         if(!pushedAuthorizationRequest.getClient_id().equals(pushedOAuthDetailRequest.getClientId())) {
             log.error("clientId does not match with the clientId in par cache");
             throw new EsignetException(ErrorConstants.INVALID_REQUEST);
-        }
-        if ("none".equalsIgnoreCase(pushedAuthorizationRequest.getPrompt())) {
-            HttpSession session = httpServletRequest.getSession(false);
-            if (session == null) {
-                log.info("OIDC request with prompt=none but user is not authenticated");
-                throw new EsignetException(ErrorConstants.LOGIN_REQUIRED);
-            }
         }
         OAuthDetailRequestV3 oAuthDetailRequestV3 = mapPushedAuthorizationRequestToOAuthDetailsRequest(pushedAuthorizationRequest);
         handleIdTokenHint(oAuthDetailRequestV3, httpServletRequest);

--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationServiceImpl.java
@@ -25,6 +25,7 @@ import io.mosip.esignet.core.spi.AuthorizationService;
 import io.mosip.esignet.core.spi.ClientManagementService;
 import io.mosip.esignet.core.spi.TokenService;
 import io.mosip.esignet.core.util.*;
+import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -167,6 +168,13 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         if(!pushedAuthorizationRequest.getClient_id().equals(pushedOAuthDetailRequest.getClientId())) {
             log.error("clientId does not match with the clientId in par cache");
             throw new EsignetException(ErrorConstants.INVALID_REQUEST);
+        }
+        if ("none".equalsIgnoreCase(pushedAuthorizationRequest.getPrompt())) {
+            HttpSession session = httpServletRequest.getSession(false);
+            if (session == null) {
+                log.info("OIDC request with prompt=none but user is not authenticated");
+                throw new EsignetException(ErrorConstants.LOGIN_REQUIRED);
+            }
         }
         OAuthDetailRequestV3 oAuthDetailRequestV3 = mapPushedAuthorizationRequestToOAuthDetailsRequest(pushedAuthorizationRequest);
         handleIdTokenHint(oAuthDetailRequestV3, httpServletRequest);

--- a/postman-collection/eSignet.postman_collection.json
+++ b/postman-collection/eSignet.postman_collection.json
@@ -597,7 +597,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"requestTime\": \"{{$isoTimestamp}}\",\n    \"request\": {\n        \"clientId\": \"{{client_id}}\",\n        \"scope\": \"{{scope}}\",\n        \"responseType\": \"code\",\n        \"redirectUri\": \"{{redirection_url}}\",\n        \"display\": \"popup\",\n        \"prompt\": \"login\",\n        \"acrValues\": \"mosip:idp:acr:generated-code\",\n        \"claims\": {{claims}},\n        \"nonce\" : \"{{$randomAlphaNumeric}}\",\n        \"state\" : \"{{state}}\",\n        \"claimsLocales\" : \"en\",\n        \"codeChallenge\" : \"{{codeChallenge}}\",\n        \"codeChallengeMethod\" : \"{{codeChallengeMethod}}\"\n    }\n}",
+							"raw": "{\n    \"requestTime\": \"{{$isoTimestamp}}\",\n    \"request\": {\n        \"clientId\": \"{{client_id}}\",\n        \"scope\": \"{{scope}}\",\n        \"responseType\": \"code\",\n        \"redirectUri\": \"{{redirection_url}}\",\n        \"display\": \"popup\",\n        \"prompt\": \"consent\",\n        \"acrValues\": \"mosip:idp:acr:generated-code\",\n        \"claims\": {{claims}},\n        \"nonce\" : \"{{$randomAlphaNumeric}}\",\n        \"state\" : \"{{state}}\",\n        \"claimsLocales\" : \"en\",\n        \"codeChallenge\" : \"{{codeChallenge}}\",\n        \"codeChallengeMethod\" : \"{{codeChallengeMethod}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1264,7 +1264,7 @@
 								},
 								{
 									"key": "prompt",
-									"value": "login",
+									"value": "consent",
 									"type": "text"
 								},
 								{
@@ -2180,7 +2180,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"requestTime\": \"{{$isoTimestamp}}\",\n    \"request\": {\n        \"clientId\": \"{{client_id}}\",\n        \"scope\": \"{{scope}}\",\n        \"responseType\": \"code\",\n        \"redirectUri\": \"{{redirection_url}}\",\n        \"display\": \"popup\",\n        \"prompt\": \"login\",\n        \"acrValues\": \"mosip:idp:acr:linked-wallet\",\n        \"claims\": {{claims}},\n        \"nonce\" : \"{{$randomAlphaNumeric}}\",\n        \"state\" : \"{{state}}\",\n        \"claimsLocales\" : \"en\",\n        \"codeChallenge\" : \"{{codeChallenge}}\",\n        \"codeChallengeMethod\" : \"{{codeChallengeMethod}}\"\n    }\n}",
+							"raw": "{\n    \"requestTime\": \"{{$isoTimestamp}}\",\n    \"request\": {\n        \"clientId\": \"{{client_id}}\",\n        \"scope\": \"{{scope}}\",\n        \"responseType\": \"code\",\n        \"redirectUri\": \"{{redirection_url}}\",\n        \"display\": \"popup\",\n        \"prompt\": \"consent\",\n        \"acrValues\": \"mosip:idp:acr:linked-wallet\",\n        \"claims\": {{claims}},\n        \"nonce\" : \"{{$randomAlphaNumeric}}\",\n        \"state\" : \"{{state}}\",\n        \"claimsLocales\" : \"en\",\n        \"codeChallenge\" : \"{{codeChallenge}}\",\n        \"codeChallengeMethod\" : \"{{codeChallengeMethod}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2827,7 +2827,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"requestTime\": \"{{$isoTimestamp}}\",\n    \"request\": {\n        \"clientId\": \"{{client_id}}\",\n        \"scope\": \"{{scope}}\",\n        \"responseType\": \"code\",\n        \"redirectUri\": \"{{redirection_url}}\",\n        \"display\": \"popup\",\n        \"prompt\": \"login\",\n        \"acrValues\": \"mosip:idp:acr:generated-code\",\n        \"claims\": {{claims_v3}},\n        \"nonce\" : \"{{$randomAlphaNumeric}}\",\n        \"state\" : \"{{state}}\",\n        \"claimsLocales\" : \"en\",\n        \"codeChallenge\" : \"{{codeChallenge}}\",\n        \"codeChallengeMethod\" : \"{{codeChallengeMethod}}\"\n    }\n}",
+							"raw": "{\n    \"requestTime\": \"{{$isoTimestamp}}\",\n    \"request\": {\n        \"clientId\": \"{{client_id}}\",\n        \"scope\": \"{{scope}}\",\n        \"responseType\": \"code\",\n        \"redirectUri\": \"{{redirection_url}}\",\n        \"display\": \"popup\",\n        \"prompt\": \"consent\",\n        \"acrValues\": \"mosip:idp:acr:generated-code\",\n        \"claims\": {{claims_v3}},\n        \"nonce\" : \"{{$randomAlphaNumeric}}\",\n        \"state\" : \"{{state}}\",\n        \"claimsLocales\" : \"en\",\n        \"codeChallenge\" : \"{{codeChallenge}}\",\n        \"codeChallengeMethod\" : \"{{codeChallengeMethod}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION
- Fix prompt=none handling for unauthenticated users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced prompt validation to reject unsupported values while maintaining compatibility for recognized types.
  * Restricted supported UI prompts configuration to 'consent' only, streamlining authentication flows.

* **Chores**
  * Added new error identifier for authentication requirement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->