### PR TITLE
[ES-2950][ES-2953] fixed htu and iat claim validation in dpop jwt

### DIFF
--- a/esignet-service/src/main/java/io/mosip/esignet/advice/DpopValidationFilter.java
+++ b/esignet-service/src/main/java/io/mosip/esignet/advice/DpopValidationFilter.java
@@ -14,9 +14,9 @@ import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import io.mosip.esignet.core.constants.Constants;
 import io.mosip.esignet.core.constants.ErrorConstants;
@@ -36,8 +36,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.util.UriComponentsBuilder;
+
 import java.io.IOException;
+import java.net.URI;
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.*;
 
 @Slf4j
@@ -56,6 +60,9 @@ public class DpopValidationFilter extends OncePerRequestFilter {
     @Value("${mosip.esignet.dpop.clock-skew:10}")
     private int maxClockSkewSeconds;
 
+    @Value("${mosip.esignet.dpop.iat.max-age-seconds}")
+    private int maxDPOPIatAgeSeconds;
+
     @Value("#{${mosip.esignet.discovery.key-values}}")
     private Map<String, Object> discoveryMap;
 
@@ -70,6 +77,9 @@ public class DpopValidationFilter extends OncePerRequestFilter {
 
     private static final String CNF = "cnf";
     private static final String JKT = "jkt";
+
+    private static final String HTU = "htu";
+    private static final String HTM = "htm";
 
     private static final String PAR_ENDPOINT = "pushed_authorization_request_endpoint";
     private static final String TOKEN_ENDPOINT = "token_endpoint";
@@ -260,14 +270,40 @@ public class DpopValidationFilter extends OncePerRequestFilter {
                 default -> discoveryMap.get(USERINFO_ENDPOINT).toString();
             };
 
-            DefaultJWTClaimsVerifier claimsSetVerifier = new DefaultJWTClaimsVerifier(new JWTClaimsSet.Builder()
-                    .claim("htm", request.getMethod())
-                    .claim("htu", reqUri)
+            DefaultJWTClaimsVerifier<SecurityContext> claimsSetVerifier = new DefaultJWTClaimsVerifier<>(new JWTClaimsSet.Builder()
+                    .claim(HTM, request.getMethod())
                     .build(), REQUIRED_CLAIMS);
             claimsSetVerifier.setMaxClockSkew(maxClockSkewSeconds);
             claimsSetVerifier.verify(claims, null);
-        } catch (BadJWTException e) {
-            log.error("Invalid request URI: {}", e.getMessage());
+
+            // htu claim validation
+            String htuClaim = claims.getStringClaim(HTU);
+            if (htuClaim == null) {
+                log.error("Missing htu claim");
+                throw new InvalidDpopHeaderException();
+            }
+            UriComponentsBuilder builder = UriComponentsBuilder.fromUri(new URI(htuClaim));
+            builder.replaceQuery(null);
+            builder.fragment(null);
+            String htuWithoutQueryAndFragment = builder.build().toUriString();
+            if (!reqUri.equals(htuWithoutQueryAndFragment)) {
+                log.error("htu claim does not match request URI. Expected: {}, Actual: {}", reqUri, htuWithoutQueryAndFragment);
+                throw new InvalidDpopHeaderException();
+            }
+
+            // iat claim validation
+            Date iat = claims.getIssueTime();
+            if (iat == null) {
+                log.error("Missing iat claim");
+                throw new InvalidDpopHeaderException();
+            }
+            if (iat.toInstant().isAfter(Instant.now().plusSeconds(maxClockSkewSeconds)) || iat.toInstant().isBefore(Instant.now().minusSeconds(maxDPOPIatAgeSeconds+maxClockSkewSeconds))) {
+                log.error("iat claim is in the future or too far in the past");
+                throw new InvalidDpopHeaderException();
+            }
+
+        } catch (Exception e) {
+            log.error("DPOP jwt claim validation failed", e);
             throw new InvalidDpopHeaderException();
         }
 

--- a/esignet-service/src/main/resources/application-default.properties
+++ b/esignet-service/src/main/resources/application-default.properties
@@ -22,9 +22,10 @@ mosip.esignet.preauthentication-expire-in-secs=300
 mosip.esignet.par.expire-seconds=60
 mosip.esignet.par.request-uri.prefix=urn:ietf:params:oauth:request_uri:
 
-# DPoP jwt clock skew in seconds to validate 'iat' and 'exp' claim
+# DPoP jwt clock skew in seconds to validate 'iat', 'nbf' and 'exp' claim
 mosip.esignet.dpop.clock-skew=10
 mosip.esignet.dpop.nonce.expire.seconds=15
+mosip.esignet.dpop.iat.max-age-seconds=60
 mosip.esignet.dpop.header-filter.paths-to-validate={'${server.servlet.path}/oauth/par', \
   '${server.servlet.path}/oauth/v2/token', \
   '${server.servlet.path}/oidc/userinfo' }

--- a/esignet-service/src/test/java/io/mosip/esignet/advice/DpopValidationFilterTest.java
+++ b/esignet-service/src/test/java/io/mosip/esignet/advice/DpopValidationFilterTest.java
@@ -70,6 +70,8 @@ public class DpopValidationFilterTest {
         ));
 
         ReflectionTestUtils.setField(filter, "objectMapper", new ObjectMapper());
+        ReflectionTestUtils.setField(filter, "maxClockSkewSeconds", 10);
+        ReflectionTestUtils.setField(filter, "maxDPOPIatAgeSeconds", 60);
     }
 
     private String createDpopJwtWithAllClaims(String httpMethod, String htuClaim, String accessToken, boolean withAth) throws Exception {
@@ -204,6 +206,21 @@ public class DpopValidationFilterTest {
     }
 
     @Test
+    public void testHtuClaimWithQueryParamsAndFragment_thenPass() throws Exception {
+        String dpopJwt = createDpopJwtWithAllClaims("GET", "http://localhost/oidc/userinfo?q1=abc&q2=xyz#frag", accessToken, true);
+
+        request.setRequestURI("/oidc/userinfo");
+        request.addHeader("DPoP", dpopJwt);
+        addAuthorizationHeader(request, accessToken);
+        request.setMethod("GET");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
     public void testDpopHeader_withEmptyJwk_thenFail() throws Exception {
         String headerJson = "{"
                 + "\"alg\":\"ES256\","
@@ -319,6 +336,49 @@ public class DpopValidationFilterTest {
         String wwwAuthenticate = response.getHeader("WWW-Authenticate");
         assertNotNull(wwwAuthenticate);
         assertTrue(wwwAuthenticate.contains("error=\"invalid_token\""));
+    }
+
+    @Test
+    public void testDpopHeader_withIatOutsideTimeLimit_thenFail() throws Exception {
+        String athHash = IdentityProviderUtil.generateB64EncodedHash(IdentityProviderUtil.ALGO_SHA_256, accessToken);
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(new JOSEObjectType("dpop+jwt"))
+                .jwk(ecJwk.toPublicJWK())
+                .build();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .jwtID(UUID.randomUUID().toString())
+                .claim("htm", "GET")
+                .claim("htu", "http://localhost/oidc/userinfo")
+                .claim("ath", athHash)
+                .issueTime(Date.from(Instant.now().plusSeconds(20))) // iat in the future beyond clock skew
+                .build();
+        SignedJWT signedJWT = new SignedJWT(header, claims);
+        signedJWT.sign(new ECDSASigner(ecJwk.toECPrivateKey()));
+        String dpopJwt = signedJWT.serialize();
+
+        request.setRequestURI("/oidc/userinfo");
+        request.addHeader("DPoP", dpopJwt);
+        addAuthorizationHeader(request, accessToken);
+        request.setMethod("GET");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.getHeader("WWW-Authenticate").contains(ErrorConstants.INVALID_DPOP_PROOF));
+        verify(filterChain, never()).doFilter(any(), any());
+
+        claims = new JWTClaimsSet.Builder(claims).issueTime(Date.from(Instant.now().minusSeconds(80))).build();
+        signedJWT = new SignedJWT(header, claims);
+        signedJWT.sign(new ECDSASigner(ecJwk.toECPrivateKey()));
+        dpopJwt = signedJWT.serialize();
+
+        request.removeHeader("DPoP");
+        request.addHeader("DPoP", dpopJwt);
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(response.getHeader("WWW-Authenticate").contains(ErrorConstants.INVALID_DPOP_PROOF));
+        verify(filterChain, never()).doFilter(any(), any());
     }
 
     @Test

--- a/esignet-service/src/test/resources/application-test.properties
+++ b/esignet-service/src/test/resources/application-test.properties
@@ -128,6 +128,7 @@ mosip.esignet.supported.client.assertion.types={'urn:ietf:params:oauth:client-as
 mosip.esignet.client-assertion.unique.jti.required=true
 
 mosip.esignet.dpop.clock-skew=10
+mosip.esignet.dpop.iat.max-age-seconds=60
 mosip.esignet.dpop.header-filter.paths-to-validate={'${server.servlet.path}/oauth/par', \
   '${server.servlet.path}/oauth/v2/token', \
   '${server.servlet.path}/oidc/userinfo' }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strengthened DPoP validation: normalizes request URI (ignoring query/fragment), enforces HTU/HTM claims, and validates iat freshness with clock-skew tolerance.

* **Behavior Changes**
  * Invalid DPoP proofs now yield consistent error responses and block request processing on failure.

* **Tests**
  * Added tests for HTU with query/fragment and iat outside allowed time window.

* **Configuration**
  * Added configurable DPoP iat max-age property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->