### PR TITLE
MOISIP-44782 : Update README.md

### DIFF
--- a/api-test/README.md
+++ b/api-test/README.md
@@ -102,7 +102,9 @@ These configurations need to be added as part of the eSignet service deployment 
     value: classpath:/mock-identity-signup-schema.json
 - **uinGenerationProcessingDelayTimeInMilliSeconds**: 600000
 - **vidGenerationProcessingDelayTimeInMilliSeconds**: 600000
-- **uinGenMaxLoopCount**: 20	
+- **uinGenMaxLoopCount**: 20
+- Automation scripts rely on **MOSIP_SIGNUP_IDENTIFIER_REGEX** for input validation during signup flows.
+Ensure that **MOSIP_SIGNUP_IDENTIFIER_REGEX** is explicitly defined in the configuration.
 
 These parameters must be included in the eSignet deployment YAML for the API Test Rig to function correctly, independent of which plugin is being used.
 


### PR DESCRIPTION
Update the README in api-test : MOSIP_SIGNUP_IDENTIFIER_REGEX required for automation in eSignet 1.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment configuration instructions with formatting improvements
  * Added documentation clarifying that automation scripts require a specific configuration parameter to be defined for signup input validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->