### PR TITLE
MOSIP-44784 - Removed snapshot for apitest commons library

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.5.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
MOSIP-44784 - Removed snapshot for apitest commons library

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API test dependency to stable release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->