### PR TITLE
[ES-2995] fixed : calling getInstance twice by using cipher pool

### DIFF
--- a/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationHelperService.java
+++ b/oidc-service-impl/src/main/java/io/mosip/esignet/services/AuthorizationHelperService.java
@@ -42,6 +42,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.async.DeferredResult;
 
 import javax.crypto.Cipher;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.NoSuchPaddingException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotNull;
@@ -128,6 +130,16 @@ public class AuthorizationHelperService {
 
     @Value("${mosip.esignet.signup-id-token-audience}")
     private String signupIDTokenAudience;
+
+    private final ThreadLocal<Cipher> cipherPool = ThreadLocal.withInitial(() -> {
+        try {
+            return Cipher.getInstance(aesECBTransformation);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new RuntimeException(
+                "Failed to initialise Cipher for transformation: "
+                + aesECBTransformation, e);
+        }
+    });
 
 
     protected void validateSendOtpCaptchaToken(String captchaToken) {
@@ -381,7 +393,7 @@ public class AuthorizationHelperService {
 
     private String encryptIndividualId(String individualId) {
         try {
-            Cipher cipher = Cipher.getInstance(aesECBTransformation);
+            Cipher cipher = cipherPool.get();
             byte[] secretDataBytes = individualId.getBytes(StandardCharsets.UTF_8);
             cipher.init(Cipher.ENCRYPT_MODE, getSecretKeyFromHSM());
             return IdentityProviderUtil.b64Encode(cipher.doFinal(secretDataBytes, 0, secretDataBytes.length));
@@ -393,7 +405,7 @@ public class AuthorizationHelperService {
 
     private String decryptIndividualId(String encryptedIndividualId) {
         try {
-            Cipher cipher = Cipher.getInstance(aesECBTransformation);
+            Cipher cipher = cipherPool.get();
             byte[] decodedBytes = IdentityProviderUtil.b64Decode(encryptedIndividualId);
             cipher.init(Cipher.DECRYPT_MODE, getSecretKeyFromHSM());
             return new String(cipher.doFinal(decodedBytes, 0, decodedBytes.length));

--- a/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationHelperServiceTest.java
+++ b/oidc-service-impl/src/test/java/io/mosip/esignet/services/AuthorizationHelperServiceTest.java
@@ -479,6 +479,74 @@ public class AuthorizationHelperServiceTest {
         Assertions.assertEquals(individualId, result);
     }
 
+    /**
+     * Verifies that an invalid cipher transformation string causes the ThreadLocal
+     * initializer to throw a RuntimeException, which is caught by encryptIndividualId
+     * and re-thrown as EsignetException(AES_CIPHER_FAILED).
+     * This tests the error-path of the cipherPool.withInitial() lambda.
+     */
+    @Test
+    public void setGetIndividualId_withInvalidTransformation_thenFail() {
+        ReflectionTestUtils.setField(authorizationHelperService, "storeIndividualId", true);
+        ReflectionTestUtils.setField(authorizationHelperService, "secureIndividualId", true);
+        ReflectionTestUtils.setField(authorizationHelperService, "aesECBTransformation", "INVALID/ALGO/NONE");
+        // No stubs for dbHelper / keyStore: cipherPool.get() throws RuntimeException
+        // (NoSuchAlgorithmException wrapped) before getSecretKeyFromHSM() is ever reached.
+
+        OIDCTransaction oidcTransaction = new OIDCTransaction();
+        try {
+            authorizationHelperService.setIndividualId("individual-id", oidcTransaction);
+            Assertions.fail("Expected EsignetException to be thrown for invalid cipher transformation");
+        } catch (EsignetException e) {
+            Assertions.assertEquals(AES_CIPHER_FAILED, e.getErrorCode());
+        }
+    }
+
+    /**
+     * Verifies that the ThreadLocal<Cipher> cipherPool reuses the same Cipher instance
+     * across multiple encrypt/decrypt calls on the same thread, while still producing
+     * correct results. The Cipher is re-armed via cipher.init() before each use, so
+     * reuse is safe regardless of previous state.
+     */
+    @Test
+    public void setGetIndividualId_cipherPoolReusedAcrossMultipleCalls() throws Exception {
+        ReflectionTestUtils.setField(authorizationHelperService, "storeIndividualId", true);
+        ReflectionTestUtils.setField(authorizationHelperService, "secureIndividualId", true);
+        ReflectionTestUtils.setField(authorizationHelperService, "aesECBTransformation", "AES/ECB/PKCS5Padding");
+        ReflectionTestUtils.setField(authorizationHelperService, "cacheSecretKeyRefId", "TRANSACTION_CACHE");
+
+        Map<String, List<KeyAlias>> keyaliasesMap = new HashMap<>();
+        KeyAlias keyAlias = new KeyAlias();
+        keyAlias.setAlias("test");
+        keyaliasesMap.put(CURRENTKEYALIAS, Arrays.asList(keyAlias));
+        Mockito.when(dbHelper.getKeyAliases(Mockito.anyString(), Mockito.anyString(), any(LocalDateTime.class))).thenReturn(keyaliasesMap);
+        KeyGenerator generator = KeyGenerator.getInstance("AES");
+        generator.init(256);
+        SecretKey key = generator.generateKey();
+        // Allow unlimited calls for multiple encrypt/decrypt round-trips
+        Mockito.when(keyStore.getSymmetricKey(Mockito.anyString())).thenReturn(key);
+
+        // First round-trip
+        String individualId1 = "individual-id-one";
+        OIDCTransaction tx1 = new OIDCTransaction();
+        authorizationHelperService.setIndividualId(individualId1, tx1);
+        Assertions.assertNotNull(tx1.getIndividualId());
+        Assertions.assertNotEquals(individualId1, tx1.getIndividualId());
+        Assertions.assertEquals(individualId1, authorizationHelperService.getIndividualId(tx1));
+
+        // Second round-trip on the same thread — cipherPool.get() must return the
+        // same Cipher object (ThreadLocal), and cipher.init() re-arms it correctly
+        String individualId2 = "individual-id-two";
+        OIDCTransaction tx2 = new OIDCTransaction();
+        authorizationHelperService.setIndividualId(individualId2, tx2);
+        Assertions.assertNotNull(tx2.getIndividualId());
+        Assertions.assertNotEquals(individualId2, tx2.getIndividualId());
+        Assertions.assertEquals(individualId2, authorizationHelperService.getIndividualId(tx2));
+
+        // Cross-check: different plaintexts must produce different ciphertexts
+        Assertions.assertNotEquals(tx1.getIndividualId(), tx2.getIndividualId());
+    }
+
     @Test
     public void setGetIndividualId_withStoreFlagSetToFalse() {
         ReflectionTestUtils.setField(authorizationHelperService, "storeIndividualId", false);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized encryption and decryption operations to provide faster and more efficient handling of secure transactions across the system

* **Bug Fixes**
  * Enhanced error detection and messaging for encryption-related failures, providing clearer diagnostics when configuration or transformation issues occur

<!-- end of auto-generated comment: release notes by coderabbit.ai -->