### PR TITLE
[ES-2962] Fixed: UI does not redirect to redirect_uri with error=login_required when oauth-details returns login_required and request_not_supported error.

### DIFF
--- a/oidc-ui/package-lock.json
+++ b/oidc-ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.10.4",
-        "@mosip/json-form-builder": "^0.1.1-beta.6",
+        "@mosip/json-form-builder": "^0.1.1-beta.8",
         "@mosip/secure-biometric-interface-integrator": "^0.1.1-beta.0",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-popover": "^1.0.7",
@@ -3255,9 +3255,9 @@
       "license": "MIT"
     },
     "node_modules/@mosip/json-form-builder": {
-      "version": "0.1.1-beta.6",
-      "resolved": "https://registry.npmjs.org/@mosip/json-form-builder/-/json-form-builder-0.1.1-beta.6.tgz",
-      "integrity": "sha512-a5npt8wGRdclhYrO3arfeCUQf+2gjbEmh1+HiT1rdDuU6Y5/DzdUf9BDo3T2Cnyq2FRGemmQNKcMESSfyshYEw==",
+      "version": "0.1.1-beta.8",
+      "resolved": "https://registry.npmjs.org/@mosip/json-form-builder/-/json-form-builder-0.1.1-beta.8.tgz",
+      "integrity": "sha512-96d+9jxtlHyPapi1mic14/yxp8vh6FhqQLjy8DF3331+0IIKF75gOTP9lnCb7i4bVRe5qLBye269x15zgeYKog==",
       "license": "MPL-2.0",
       "dependencies": {
         "date-fns": "^4.1.0",

--- a/oidc-ui/package.json
+++ b/oidc-ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.10.4",
-    "@mosip/json-form-builder": "^0.1.1-beta.6",
+    "@mosip/json-form-builder": "^0.1.1-beta.8",
     "@mosip/secure-biometric-interface-integrator": "^0.1.1-beta.0",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-popover": "^1.0.7",

--- a/oidc-ui/src/components/Authorize.js
+++ b/oidc-ui/src/components/Authorize.js
@@ -68,8 +68,10 @@ export default function Authorize({ authService }) {
                 oAuthDetailsResponse.errors[0].errorMessage
               );
               window.onbeforeunload = null;
-              url.searchParams.set('state', extractParam('state'));
-
+              const state = extractParam('state');
+              if (state !== null) {
+                url.searchParams.set('state', state);
+              }
               window.location.replace(url.toString());
               return;
             }

--- a/oidc-ui/src/components/Authorize.js
+++ b/oidc-ui/src/components/Authorize.js
@@ -42,7 +42,22 @@ export default function Authorize({ authService }) {
             ) {
               const baseRedirectUri = extractParam('redirect_uri');
 
-              const url = new URL(baseRedirectUri);
+              if (!baseRedirectUri) {
+                setOAuthDetailResponse(null);
+                setError('invalid_redirect_uri');
+                setStatus(states.ERROR);
+                return;
+              }
+
+              let url;
+              try {
+                url = new URL(baseRedirectUri);
+              } catch {
+                setOAuthDetailResponse(null);
+                setError('invalid_redirect_uri');
+                setStatus(states.ERROR);
+                return;
+              }
 
               url.searchParams.set(
                 'error',
@@ -52,9 +67,11 @@ export default function Authorize({ authService }) {
                 'error_description',
                 oAuthDetailsResponse.errors[0].errorMessage
               );
+              window.onbeforeunload = null;
               url.searchParams.set('state', extractParam('state'));
 
               window.location.replace(url.toString());
+              return;
             }
 
             setOAuthDetailResponse(null);

--- a/oidc-ui/src/components/Authorize.js
+++ b/oidc-ui/src/components/Authorize.js
@@ -15,6 +15,7 @@ export default function Authorize({ authService }) {
   const [oAuthDetailResponse, setOAuthDetailResponse] = useState(null);
   const [error, setError] = useState(null);
   const [searchParams] = useSearchParams();
+  const extractParam = (param) => searchParams.get(param);
 
   const navigate = useNavigate();
 
@@ -28,6 +29,34 @@ export default function Authorize({ authService }) {
           if (oAuthDetailsResponse.errors.length === 0) {
             setOAuthDetailResponse(oAuthDetailsResponse);
           } else {
+            let errorCodesThatRedirects = [
+              'login_required',
+              'request_not_supported',
+            ];
+
+            if (
+              oAuthDetailsResponse &&
+              errorCodesThatRedirects.includes(
+                oAuthDetailsResponse.errors[0].errorCode
+              )
+            ) {
+              const baseRedirectUri = extractParam('redirect_uri');
+
+              const url = new URL(baseRedirectUri);
+
+              url.searchParams.set(
+                'error',
+                oAuthDetailsResponse.errors[0].errorCode
+              );
+              url.searchParams.set(
+                'error_description',
+                oAuthDetailsResponse.errors[0].errorMessage
+              );
+              url.searchParams.set('state', extractParam('state'));
+
+              window.location.replace(url.toString());
+            }
+
             setOAuthDetailResponse(null);
             setError(oAuthDetailsResponse.errors[0].errorCode);
             setStatus(states.ERROR);
@@ -44,8 +73,6 @@ export default function Authorize({ authService }) {
           const payload = { clientId, requestUri };
           await post_ParOauthDetails(payload).then(handleResponse);
         } else {
-          const extractParam = (param) => searchParams.get(param);
-
           const request = {
             nonce: extractParam('nonce'),
             state: extractParam('state'),

--- a/oidc-ui/src/components/Authorize.js
+++ b/oidc-ui/src/components/Authorize.js
@@ -42,15 +42,13 @@ export default function Authorize({ authService }) {
             ) {
               const baseRedirectUri = extractParam('redirect_uri');
 
-              if (!baseRedirectUri) {
-                setOAuthDetailResponse(null);
-                setError('invalid_redirect_uri');
-                setStatus(states.ERROR);
-                return;
-              }
-
               let url;
+
               try {
+                if (!baseRedirectUri) {
+                  throw new Error('Missing redirect URI');
+                }
+
                 url = new URL(baseRedirectUri);
               } catch {
                 setOAuthDetailResponse(null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded a UI dependency to a newer patch-beta version to incorporate upstream fixes and improvements.

* **Bug Fixes**
  * Improved authorization error handling: for specific auth errors the app now redirects to the configured redirect URI with error details encoded in the query string; if the redirect URI is missing or invalid, the flow now surfaces an explicit invalid-redirect error and transitions to an error state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->